### PR TITLE
Fix to American Made Solar

### DIFF
--- a/_challenges/1033-american-made-solar-prize-round-2.md
+++ b/_challenges/1033-american-made-solar-prize-round-2.md
@@ -14,8 +14,8 @@ partners-non-federal:
 external-url: https://americanmadechallenges.org/solarprize/round2
 total-prize-offered-cash: $3,000,000
 type-of-challenge: 
-submission-start: 
-submission-end: 2019/07/16
+submission-start: 2019/03/22
+submission-end: 2019/07/16 2 p.m. ET
 submission-link:  
 prizes: true
 ---


### PR DESCRIPTION
No time was specified; it was defaulting to midnight. Verified against original challenge submission. Fixed.