### PR TITLE
fix non-monetary prizes info in 1064

### DIFF
--- a/_challenges/1064-rust-busters-challenge.md
+++ b/_challenges/1064-rust-busters-challenge.md
@@ -64,7 +64,7 @@ challenge-manager-email: kyla@herox.com
 <p><em>Phase 2: $100,000</em> </p>
 <p>Up to 3 winners will share the $100,000 prize.</p>
 <p><strong>Non-monetary Prizes</strong></p>
-<p>Phase 2 participants will receive field-test data for their technologies.</p>
+<p>Phase 2 participants will receive laboratory and field testing data for their technologies.</p>
 <p>Phase 2 winners:</p>
 <ul>
 <li>May be invited to present their work jointly with Reclamation at either the NACE 2022 International Corrosion Conference and Expo or the SSPC's Coatings+2022 Conference.</li>


### PR DESCRIPTION
## Preview Links

NOTE: Only an update to text under Prizes section so not including home preview link.

[Home](addPreviewBranchLinkHere)

[Challenge Page](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/challenges-and-prizes/fix-non-monetary-prizes-info-in-1064/challenge/rust-busters-challenge/)


## Completion Checklist

- filename starts with the challenge ID #  example-->(1052-challenge-title.md)

- images/docs have been added to the appropriate [assets](https://github.com/GSA/challenges-and-prizes/tree/master/assets) folder

- add alt tags to images in the challenge content body

- test all content links

- test skip links

- add @greensteph as a reviewer when you are ready to go Live

----

>To Note: you cannot use colons in the front-matter data fields
