### PR TITLE
Create test-challenge-no-date.md

### DIFF
--- a/_challenges/test-challenge-no-date.md
+++ b/_challenges/test-challenge-no-date.md
@@ -1,0 +1,57 @@
+---
+layout: front-matter-data
+permalink: /challenge/test-software-challenge/
+challenge-id:
+status: open
+sidenav: true
+card-image: /assets/images/cards/challenge-gov.png
+agency-logo:
+challenge-title: Test Software Challenge
+tagline: Develop some software for DOE.
+agency: Department of Energy
+partner-agencies-federal:
+partners-non-federal:
+external-url:
+total-prize-offered-cash:
+type-of-challenge: Software
+submission-start: Coming Soon - Anticipated April 2020
+submission-end:
+submission-link:
+prizes: true
+fiscal-year: FY20
+legal-authority: America COMPETES Act
+challenge-manager: EB
+challenge-manager-email: eric.beidel@gsa.gov
+---
+
+
+
+<!-- Description start -->
+### Description
+{: .text-accent-warm-dark .font-heading-lg .challenge-section}
+
+This is a description of the software challenge. More details coming soon.
+
+<!-- Prizes start -->
+### Prizes
+{: .text-accent-warm-dark .font-heading-lg .challenge-section}
+
+Tons of money up for grabs.
+
+<!-- Rules start -->
+### Rules 
+{: .text-accent-warm-dark .font-heading-lg .challenge-section}
+
+Offiial rules will be posted in April.
+
+<!-- Judging start -->
+### Judging Criteria
+{: .text-accent-warm-dark .font-heading-lg .challenge-section}
+
+Judging details will be posted in April.
+
+<!--  How To Enter start -->
+### How To Enter
+{: .text-accent-warm-dark .font-heading-lg .challenge-section}
+
+Instructions on how to enter will be posted in April.


### PR DESCRIPTION
## Preview Links
[Home](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/challenges-and-prizes/create-TEST-challenge-no-date/)

[Challenge Page](https://cg-06ab120d-836f-49a2-bc22-9dfb1585c3c6.app.cloud.gov/preview/gsa/challenges-and-prizes/create-TEST-challenge-no-date/challenge/test-software-challenge/)

**DO NOT PUBLISH**
@greensteph 
I put no date in end date and it surfaces challenge as first on listing page, as you anticipated. It also posts it with the ET there even with no date.

Also, on the challenge page, it converted "Coming Soon - Anticipated April 2020" that I put in for the start date to the actual time of midnight on April 1, 2020.

So - I think we need to tell the agency in question they need to have actual dates and times (even if default midnight). They can come back and change them closer to launch, but they would need to give us dates to put in and they can use the description section to say, "This challenge is anticipated to open sometime in April. Check back for official dates and times." or whatever they want to say.

Do you agree?


## Completion Checklist

- filename starts with the challenge ID #  example-->(1052-challenge-title.md)

- images/docs have been added to the appropriate [assets](https://github.com/GSA/challenges-and-prizes/tree/master/assets) folder

- add alt tags to images in the challenge content body

- test all content links

- test skip links

- add @greensteph as a reviewer when you are ready to go Live

----

>To Note: you cannot use colons in the front-matter data fields
