### PR TITLE
Update 1095 submission close

### DIFF
--- a/_challenges/1095-precision-FDA-9.md
+++ b/_challenges/1095-precision-FDA-9.md
@@ -15,7 +15,7 @@ external-url: https://go.usa.gov/xd9nG
 total-prize-offered-cash:
 type-of-challenge: Analytics, visualization, and algorithms
 submission-start: 2020/01/17 02:20 PM
-submission-end: 2020/02/29 11:59 PM
+submission-end: 2020/02/28 11:59 PM
 submission-link:
 prizes: true
 fiscal-year: FY20


### PR DESCRIPTION
## Preview Links
[Home](https://federalist-2c628203-05c2-48ab-8f87-3eda79380559.app.cloud.gov/preview/gsa/challenges-and-prizes/Update-1095-submmission-close/)

They provided the wrong submission end date because of time zone issues on their side. Correcting the date for tile display.

[Challenge Page](addLinktoChallengeHere)


## Completion Checklist

- filename starts with the challenge ID #  example-->(1052-challenge-title.md)

- images/docs have been added to the appropriate [assets](https://github.com/GSA/challenges-and-prizes/tree/master/assets) folder

- add alt tags to images in the challenge content body

- test all content links

- test skip links

- add @greensteph as a reviewer when you are ready to go Live

----

>To Note: you cannot use colons in the front-matter data fields
