### PR TITLE
Sidenav update

### DIFF
--- a/_challenges/1087-2020-debut-challenge.md
+++ b/_challenges/1087-2020-debut-challenge.md
@@ -3,7 +3,7 @@ layout: front-matter-data
 permalink: /challenge/2020-debut-challenge/
 challenge-id: 1087
 status: open
-sidenav: false
+sidenav: true
 card-image: /assets/images/cards/DEBUT.png
 agency-logo: NIH_Master_Logo_Vertical_2Color.jpg
 challenge-title: 2020 Design by Biomedical Undergraduate Teams (DEBUT) Challenge

--- a/_includes/sidenav-front-matter-data.html
+++ b/_includes/sidenav-front-matter-data.html
@@ -1,30 +1,36 @@
-{% comment %} 
-The sidenav is not loaded by default on the main pages. To include this navigation you can either use the
-_layouts/page.html layout template, or you can add "sidenav: true" in the front-matter of your pages
-{% endcomment %}
 
 <aside class="usa-layout-docs-sidenav desktop:grid-col-3 usa-section">
     {% include agency-front-matter-data.html %}
-    {% if page.sidenav == true %}
     <hr>
+    {% if page.sidenav == true %}
   <nav>
     <h3 class="text-base-dark">Page Contents</h3>
     <ul class="usa-sidenav">
+      {% if page.description %}
       <li class="usa-sidenav__item">
         <a class="text-accent-warm-dark" href="#description">Description<span class="sr-only"> (in-page link)</span></a>
       </li>
+      {% endif %}
+      {% if page.prizes %}
       <li class="usa-sidenav__item">
         <a href="#prizes">Prizes<span class="sr-only"> (in-page link)</span></a>
       </li>
+      {% endif %}
+      {% if page.rules %}
       <li class="usa-sidenav__item">
         <a href="#rules">Rules<span class="sr-only"> (in-page link)</span></a>
       </li>
+      {% endif %}
+      {% if page.judging %}
       <li class="usa-sidenav__item">
         <a href="#judging-criteria">Judging Criteria<span class="sr-only"> (in-page link)</span></a>
       </li>
+      {% endif %}
+      {% if page.how-to-enter %}
       <li class="usa-sidenav__item">
         <a href="#how-to-enter">How To Enter<span class="sr-only"> (in-page link)</span></a>
       </li>
+      {% endif %}
       {% if page.status == "open" %}
       <li class="usa-sidenav__item">
         <a href="#contact">Point of Contact<span class="sr-only"> (in-page link)</span></a>

--- a/_layouts/front-matter-data-markdownify-content.html
+++ b/_layouts/front-matter-data-markdownify-content.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-permalink: json-page
 ---
   
 <div class="grid-container">

--- a/_layouts/front-matter-data.html
+++ b/_layouts/front-matter-data.html
@@ -59,10 +59,8 @@ permalink: json-page
                     {% endif %}
                     {{ content }} 
                 </div>
-                {% if page.external-url == nil  %}
                 {% if page.status == "open"  %}
                 {% include challenge-poc.html %}
-                {% endif %}
                 {% endif %}
             </div>
       


### PR DESCRIPTION
- for individual challenge pages, makes the sidenav skip links appear only when the corresponding front matter item exists