### PR TITLE
Add redirects to GSA.gov content for federal challenge managers

### DIFF
--- a/pages/community.md
+++ b/pages/community.md
@@ -1,7 +1,8 @@
 ---
 layout: page
-permalink: /community/
 title: Challenge & Prize Community
+permalink: /community/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Join-the-community
 ---
 
 # Challenge & Prize Community

--- a/pages/federal-agency-faqs.html
+++ b/pages/federal-agency-faqs.html
@@ -1,7 +1,8 @@
 ---
 layout: page
-permalink: /federal-agency-faqs/
 title: Federal Agency FAQs
+permalink: /federal-agency-faqs/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions
 ---
 <div class="usa-faq-sec-wrap">
   <h1 class="margin-bottom-0">Federal Agency FAQs</h1>

--- a/pages/resources-managers.md
+++ b/pages/resources-managers.md
@@ -99,8 +99,8 @@ title: Resources for Federal Challenge Managers
     </svg>
     <h2 class="usa-card__heading">Toolkit</h2>
     <p class="usa-card__text">Resources on running challenges.</p>
-    <a href="{{ site.baseurl }}/assets/document-library/Challenge-Gov-Federal-Agency-Toolkit.pdf" class="usa-button usa-button--primary margin-bottom-0">
-      <span style="color: #ffffff;">Read toolkit</span>
+    <a href="https://www.gsa.gov/system/files/prize-challenge-toolkit-2026.pdf" class="usa-button usa-button--primary margin-bottom-0">
+      <span style="color: #ffffff;">Read 2026 prize and challenge toolkit [PDF - 1 MB]</span>
     </a>
   </div>
 </div>

--- a/pages/toolkit/case-studies/ai-for-critical-mineral-assessment-competition.md
+++ b/pages/toolkit/case-studies/ai-for-critical-mineral-assessment-competition.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/ai-for-critical-mineral-assessment-competition/
 layout: toolkit
 title: Case Study - AI for Critical Mineral Assessment Competition
+permalink: /toolkit/case-studies/ai-for-critical-mineral-assessment-competition/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap" class="usa-prose">

--- a/pages/toolkit/case-studies/artists-inspire-astronauts.md
+++ b/pages/toolkit/case-studies/artists-inspire-astronauts.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/artists-inspire-astronauts/
 layout: toolkit
 title: Case Study - Artists Inspire Astronauts Challenge
+permalink: /toolkit/case-studies/artists-inspire-astronauts/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap" class="usa-prose">

--- a/pages/toolkit/case-studies/bridging-the-word-gap-challenge.md
+++ b/pages/toolkit/case-studies/bridging-the-word-gap-challenge.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/bridging-the-word-gap-challenge/
 layout: toolkit
 title: Case Study - Bridging the Word Gap Challenge
+permalink: /toolkit/case-studies/bridging-the-word-gap-challenge/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/case-studies.md
+++ b/pages/toolkit/case-studies/case-studies.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/
 layout: toolkit
 title: Toolkit Case Studies
+permalink: /toolkit/case-studies/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container case-studies">
     <h1 class="usa-text-primary-dark text-center">Case Studies</h1>

--- a/pages/toolkit/case-studies/cdc-no-petri-dish.md
+++ b/pages/toolkit/case-studies/cdc-no-petri-dish.md
@@ -2,6 +2,8 @@
 permalink: /toolkit/case-studies/cdc-no-petri-dish/
 layout: toolkit
 title: Case Study - No Petri Dish
+permalink: /toolkit/case-studies/cdc-no-petri-dish/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/cdc-predict-the-flu.md
+++ b/pages/toolkit/case-studies/cdc-predict-the-flu.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/cdc-predict-the-flu/
 layout: toolkit
 title: Case Study - Predict the Influenza Season
+permalink: /toolkit/case-studies/cdc-predict-the-flu/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/cpsc-carbon-monoxide.md
+++ b/pages/toolkit/case-studies/cpsc-carbon-monoxide.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/cpsc-carbon-monoxide/
 layout: toolkit
 title: Case Study - Carbon Monoxide Poster Contest
+permalink: /toolkit/case-studies/cpsc-carbon-monoxide/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/digital-service-contracting-professional-training-and-development-program.md
+++ b/pages/toolkit/case-studies/digital-service-contracting-professional-training-and-development-program.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/digital-service-contracting-professional-training-and-development-program/
 layout: toolkit
 title: Case Study - Digital Service Contracting Professional Training and Development Program
+permalink: /toolkit/case-studies/digital-service-contracting-professional-training-and-development-program/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/epa-nutrient-sensor.md
+++ b/pages/toolkit/case-studies/epa-nutrient-sensor.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/epa-nutrient-sensor/
 layout: toolkit
 title: Case Study - Nutrient Sensor Challenge
+permalink: /toolkit/case-studies/epa-nutrient-sensor/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/fishing-for-fishermen-maritime-data-challenge.md
+++ b/pages/toolkit/case-studies/fishing-for-fishermen-maritime-data-challenge.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/fishing-for-fishermen-maritime-data-challenge/
 layout: toolkit
 title: Case Study - "Fishing for Fishermen" Maritime Data Challenge
+permalink: /toolkit/case-studies/fishing-for-fishermen-maritime-data-challenge/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/ftc-zapping-rachel.md
+++ b/pages/toolkit/case-studies/ftc-zapping-rachel.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/ftc-zapping-rachel/
 layout: toolkit
 title: Case Study - "Zapping Rachel"
+permalink: /toolkit/case-studies/ftc-zapping-rachel/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/future-engineers-3d-space-design.md
+++ b/pages/toolkit/case-studies/future-engineers-3d-space-design.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/future-engineers-3d-space-design/
 layout: toolkit
 title: Case Study - Future Engineers 3D Space Design
+permalink: /toolkit/case-studies/future-engineers-3d-space-design/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/gear-center-challenge.md
+++ b/pages/toolkit/case-studies/gear-center-challenge.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/gear-center-challenge/
 layout: toolkit
 title: Case Study - GEAR Center Challenge
+permalink: /toolkit/case-studies/gear-center-challenge/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap" class="usa-prose">

--- a/pages/toolkit/case-studies/gsa-travel-data.md
+++ b/pages/toolkit/case-studies/gsa-travel-data.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/gsa-travel-data/
 layout: toolkit
 title: Case Study - Travel Data Challenge
+permalink: /toolkit/case-studies/gsa-travel-data/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/head-health-challenge.md
+++ b/pages/toolkit/case-studies/head-health-challenge.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/head-health-challenge-iii/
 layout: toolkit
 title: Case Study - Head Health Challenge III
+permalink: /toolkit/case-studies/head-health-challenge-iii/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/hidden-signals-challenge.md
+++ b/pages/toolkit/case-studies/hidden-signals-challenge.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/hidden-signals-challenge/
 layout: toolkit
 title: Case Study - Hidden Signals Challenge
+permalink: /toolkit/case-studies/hidden-signals-challenge/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
  <div id="page-wrap">

--- a/pages/toolkit/case-studies/hud-affordable-housing.md
+++ b/pages/toolkit/case-studies/hud-affordable-housing.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/hud-affordable-housing/
 layout: toolkit
 title: Case Study - Innovation in Affordable Housing
+permalink: /toolkit/case-studies/hud-affordable-housing/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/iarpa-instinct.md
+++ b/pages/toolkit/case-studies/iarpa-instinct.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/iarpa-instinct/
 layout: toolkit
 title: Case Study - INSTINCT challenge
+permalink: /toolkit/case-studies/iarpa-instinct/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/iss-food-intake-tracker.md
+++ b/pages/toolkit/case-studies/iss-food-intake-tracker.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/iss-food-intake-tracker/
 layout: toolkit
 title: Case Study - ISS Food Intake Tracker
+permalink: /toolkit/case-studies/iss-food-intake-tracker/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/nci-breast-cancer-startup-challenge.md
+++ b/pages/toolkit/case-studies/nci-breast-cancer-startup-challenge.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/nci-breast-cancer-startup-challenge/
 layout: toolkit
 title: Case Study - Breast Cancer Startup Challenge
+permalink: /toolkit/case-studies/nci-breast-cancer-startup-challenge/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/nei-audacious-goals.md
+++ b/pages/toolkit/case-studies/nei-audacious-goals.md
@@ -1,7 +1,9 @@
 ---
-permalink: /toolkit/case-studies/nei-audacious-goals/
+
 layout: toolkit
 title: Case Study - Audacious Goals in Vision Research
+permalink: /toolkit/case-studies/nei-audacious-goals/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/nih-follow-that-cell.md
+++ b/pages/toolkit/case-studies/nih-follow-that-cell.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/nih-follow-that-cell/
 layout: toolkit
 title: Case Study - Follow That Cell
+permalink: /toolkit/case-studies/nih-follow-that-cell/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/nist-reference-data.md
+++ b/pages/toolkit/case-studies/nist-reference-data.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/nist-reference-data/
 layout: toolkit
 title: Case Study - Reference Data Challenge
+permalink: /toolkit/case-studies/nist-reference-data/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/strain-measurement.md
+++ b/pages/toolkit/case-studies/strain-measurement.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/strain-measurement/
 layout: toolkit
 title: Case Study - Strain Measurement
+permalink: /toolkit/case-studies/strain-measurement/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/ultra-high-speed-apps.md
+++ b/pages/toolkit/case-studies/ultra-high-speed-apps.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/ultra-high-speed-apps/
 layout: toolkit
 title: Case Study - Ultra-High Speed Apps
+permalink: /toolkit/case-studies/ultra-high-speed-apps/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/usaid-desal-prize.md
+++ b/pages/toolkit/case-studies/usaid-desal-prize.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/usaid-desal-prize/
 layout: toolkit
 title: Case Study - DESAL Prize
+permalink: /toolkit/case-studies/usaid-desal-prize/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/usaid-enabling-writers.md
+++ b/pages/toolkit/case-studies/usaid-enabling-writers.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/usaid-enabling-writers/
 layout: toolkit
 title: Case Study - Enabling Writers
+permalink: /toolkit/case-studies/usaid-enabling-writers/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/case-studies/wave-energy-prize.md
+++ b/pages/toolkit/case-studies/wave-energy-prize.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/case-studies/wave-energy-prize/
 layout: toolkit
 title: Case Study - Wave Energy Prize
+permalink: /toolkit/case-studies/wave-energy-prize/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 <div class="grid-container padding-bottom-5">
   <div id="page-wrap">

--- a/pages/toolkit/faq.md
+++ b/pages/toolkit/faq.md
@@ -1,7 +1,8 @@
 ---
-permalink: /toolkit/faq/
 layout: toolkit
 title: Toolkit - Frequently Asked Questions
+permalink: /toolkit/faq/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions
 ---
 
 <div class="grid-container">

--- a/pages/toolkit/resources.md
+++ b/pages/toolkit/resources.md
@@ -1,7 +1,8 @@
 ---
 layout: toolkit-base
-permalink: /toolkit/resources/
 title: Toolkit - Resources
+permalink: /toolkit/resources/
+redirect_to: https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
 ---
 
 <div class="toolkit usa-toolkit">


### PR DESCRIPTION
Updated the following cards and linked content on the Resources for Federal Challenge Managers page:

* Redirect toolkit FAQs and federal agency FAQS to main landing page https://www.gsa.gov/technology/government-it-initiatives/prize-competitions
* Redirect community to https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Join-the-community
* Redirect all case studies to https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
* Redirect toolkit resources to https://www.gsa.gov/technology/government-it-initiatives/prize-competitions#tab--Resources
* Update link for toolkit PDF to the new 2026 PDF on GSA.gov

Left user guide, need help, and stay informed cards as-is for now.

[Preview Resources for Federal Challenge Managers
](https://federalist-2c628203-05c2-48ab-8f87-3eda79380559.sites.pages.cloud.gov/preview/gsa/challenges-and-prizes/aff-content-updates/resources-managers/)