### PR TITLE
Revise README for Challenge.gov sunset and updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-This repository was used to publish content on the Challenge.gov website.
+This repository was used to ​d​evelop and maintain Challenge.gov, an open source platform for federal practitioners to manage their challenges and prize competitions.
 
 Challenge.gov was sunset in March 2026, and the content has moved to other government websites.
 
-# For public innovators
+## For public innovators
 
 If you want to participate in federal challenges and prize competitions, visit the [innovation section on USA.gov](https://www.usa.gov/innovation) to find opportunities.
 
@@ -12,9 +12,9 @@ You can explore and learn about:
 * Other federal websites that list challenges
 * Citizen science projects
 
-# For federal challenge managers
+## For federal challenge managers
 
-Explore [guidance and resources about running challenges and prize competitions on GSA.gov](https://www.gsa.gov/technology/government-it-initiatives/prize-competitions). 
+Explore [guidance and resources about running challenges and prize competitions on GSA.gov](https://www.gsa.gov/technology/government-it-initiatives/prize-competitions).
 
 These resources cover:
 
@@ -23,3 +23,21 @@ These resources cover:
 * Contracting support
 * Federal laws and requirements
 * Best practices and a toolkit for managing challenges
+
+## For our open source friends
+There were three repositories that make up the Challenge.gov website and app family.
+
+### Static website
+_Informational site and documentation about challenges._
+
+[https://github.com/GSA/challenges-and-prizes/](https://github.com/GSA/challenges-and-prizes/)
+
+### Platform
+_Challenge portal and functionality for building and managing challenges, submitting challenges, and evaluating challenge submissions (feature branch)._
+
+[https://github.com/GSA/Challenge_platform](https://github.com/GSA/Challenge_platform )
+
+### Pre-platform website
+_Mentioned only to avoid confusion because of the repo name._
+
+[https://github.com/GSA/Challenge_gov](https://github.com/GSA/Challenge_gov)


### PR DESCRIPTION
Updated the README to reflect the development and maintenance of Challenge.gov, added sections for public innovators, federal challenge managers, and open source contributors.